### PR TITLE
Fix the typo in Builder.php

### DIFF
--- a/src/Lavary/Menu/Builder.php
+++ b/src/Lavary/Menu/Builder.php
@@ -517,7 +517,7 @@ class Builder {
 					
 			if( $item->hasChildren() ) {
 				$items .= "<{$type}>";
-				$items .= $this->render($type, $item->id());
+				$items .= $this->render($type, $item->id;
 				$items .= "</{$type}>";
 			}
 			


### PR DESCRIPTION
Should call the $item->title instead of $item->title(), also, typo for the $item->hasChilderen()
