### PR TITLE
Add ``depth`` to menu object, so we know where level we are.

### DIFF
--- a/src/Lavary/Menu/Item.php
+++ b/src/Lavary/Menu/Item.php
@@ -59,6 +59,13 @@ class Item {
 	public $attributes = array();
 
 	/**
+	 * Depth of children
+	 *
+	 * @var integer
+	 */
+	public $depth;
+
+	/**
 	 * Creates a new Lavary\Menu\MenuItem instance.
 	 *
 	 * @param  string  $title
@@ -76,6 +83,7 @@ class Item {
 		$this->nickname    = camel_case($title);
 		$this->attributes  = $this->builder->extractAttributes($options); 
 		$this->parent      = (is_array($options) && isset($options['parent'])) ? $options['parent'] : null;
+		$this->depth	   = 1;
 		
 		
 		// Storing path options with each link instance.
@@ -258,6 +266,9 @@ class Item {
 	 */
 	public function children()
 	{
+		// increase the depth
+		$this->depth++;
+		
 		return $this->builder->whereParent($this->id);
 	}
 


### PR DESCRIPTION
Reference to lavary#28 (comment)

Sample code

```
@foreach($items as $item)
  <li@lm-attrs($item) @lm-endattrs>
      <a href="{{ $item->url }}">{{ $item->title }} </a>
      @if($item->hasChildren())
        <ul class="nav nav-{{ numToOrdinalWord($item->depth) }}-level">
              @include('admin::partials/custom-menu-items', array('items' => $item->children()))
        </ul>
      @endif
  </li>
@endforeach
```

`numToOrdinalWord` is custom function to replace 1 to first, 2 to second, etc

``` php
if ( ! function_exists('numToOrdinalWord')) {

    function numToOrdinalWord($num)
    {
        $first_word     =
array('eth','first','second','third','fouth','fifth','sixth','seventh','eighth','ninth','tenth','elevents','twelfth','thirteenth','fourteenth','fifteenth','sixteenth','seventeenth','eighteenth','nineteenth','twentieth');
        $second_word    = array('','','twenty','thirty','forty','fifty');

        if ($num <= 20)
            return $first_word[$num];

        $first_num  = substr($num,-1,1);
        $second_num = substr($num,-2,1);

        return str_replace('y-eth','ieth',$second_word[$second_num].'-'.$first_word[$first_num]);
    }

}
```
