### PR TITLE
Get ``depth`` from current $item

### DIFF
--- a/src/Lavary/Menu/Item.php
+++ b/src/Lavary/Menu/Item.php
@@ -273,6 +273,16 @@ class Item {
 	}
 
 	/**
+	 * Returns depth of $item
+	 * 
+	 * @return Integer
+	 */
+	public function depth()
+	{
+		return static::$depth;
+	}
+
+	/**
 	 * Returns all childeren of the item
 	 *
 	 * @return Lavary\Menu\Collection


### PR DESCRIPTION
From looping `$item->children()` get current depth by calling `$item->depth()`

Sample code

```
@foreach($items as $item)
  <li@lm-attrs($item) @lm-endattrs>
      <a href="{{ $item->url }}">{{ $item->title }} </a>
      @if($item->hasChildren())
        <ul class="nav nav-{{ numToOrdinalWord($item->depth()) }}-level">
              @include('admin::partials/custom-menu-items', array('items' => $item->children()))
        </ul>
      @endif
  </li>
@endforeach
```

`numToOrdinalWord` is custom function to replace 1 to first, 2 to second, etc. Not included in this package, just for reference only

``` php
if ( ! function_exists('numToOrdinalWord')) {

    function numToOrdinalWord($num)
    {
        $first_word     =
array('eth','first','second','third','fouth','fifth','sixth','seventh','eighth','ninth','tenth','elevents','twelfth','thirteenth','fourteenth','fifteenth','sixteenth','seventeenth','eighteenth','nineteenth','twentieth');
        $second_word    = array('','','twenty','thirty','forty','fifty');

        if ($num <= 20)
            return $first_word[$num];

        $first_num  = substr($num,-1,1);
        $second_num = substr($num,-2,1);

        return str_replace('y-eth','ieth',$second_word[$second_num].'-'.$first_word[$first_num]);
    }

}
```
