### PR TITLE
Fix for remove accentuation in nickname on create a new item.

### DIFF
--- a/src/Lavary/Menu/Item.php
+++ b/src/Lavary/Menu/Item.php
@@ -1,5 +1,7 @@
 <?php namespace Lavary\Menu;
 
+use Str;
+
 class Item {
 	
 	/**
@@ -73,7 +75,7 @@ class Item {
 		$this->builder     = $builder;
 		$this->id          = $id;
 		$this->title       = $title;
-		$this->nickname    = camel_case($title);
+		$this->nickname    = camel_case(Str::ascii($title));
 		$this->attributes  = $this->builder->extractAttributes($options); 
 		$this->parent      = (is_array($options) && isset($options['parent'])) ? $options['parent'] : null;
 		


### PR DESCRIPTION
Remove accentuation in nickname on create a new item.
Ex:
```php
$menu->add('Cotação'); // This bugs nickname.
```

The fix resolve access for items with accentuation:
```php
$menu->cotacao->add(...);
```