### PR TITLE
Fixes Class 'Str' not found namespace

### DIFF
--- a/src/Lavary/Menu/Item.php
+++ b/src/Lavary/Menu/Item.php
@@ -1,6 +1,6 @@
 <?php namespace Lavary\Menu;
 
-use Str;
+use Illuminate\Support\Str;
 
 class Item {
 	


### PR DESCRIPTION
In Laravel 5.1.2 I kept getting the error:

Class 'Str' not found, I added a full namespace and it works.