### PR TITLE
Fix `sortBy` Menu Builder when we use string as `$sort_by`

### DIFF
--- a/src/Lavary/Menu/Builder.php
+++ b/src/Lavary/Menu/Builder.php
@@ -486,7 +486,7 @@ class Builder {
 		}
 		
 		// running the sort proccess on the sortable items
-		$this->items->sort(function ($f, $s) use ($sort_by, $sort_type) {
+		$this->items	= $this->items->sort(function ($f, $s) use ($sort_by, $sort_type) {
 			
 			$f = $f->$sort_by;
 			$s = $s->$sort_by;


### PR DESCRIPTION
This PR fix when we want to sort menu by string, now we can make sure that our items are ordered.

```php
// define menu
$this->app->make('menu')->make('sidebar', function($menu) {
	$menu->add('Dashboard', ['route' => 'dashboard.index'])->data('order', 1);
});

// later .. add item to menu
$menu	= $this->app->make('menu')->get('sidebar');

$master	= $menu->add('Master', 'javascript:void(0)')->data('order', 3);

// later again .. add item to menu
$menu	= $this->app->make('menu')->get('sidebar');

$user	= $menu->add('Users', 'javascript:void(0)')->data('order', 2);

// finally..get menu
Menu::get($name)->sortBy('order')->asUl();
```

And that will return
- Dashboard
- Users
- Master

Thanks