### PR TITLE
Fixed bug id method generate id & parent same value

### DIFF
--- a/src/Lavary/Menu/Builder.php
+++ b/src/Lavary/Menu/Builder.php
@@ -79,7 +79,7 @@ class Builder {
 	 */
 	protected function id()
 	{
-		return uniqid();
+		return uniqid(rand());
 	}
 
 	/**


### PR DESCRIPTION
id method generate id same value some time.
if parent & id in var $items same value.
render function call recursive function it infinity loop in same id. it makes php timeout error & memory limit

FatalErrorException in Builder.php line 516:
Allowed memory size of 134217728 bytes exhausted (tried to allocate 647168 bytes)

`\Menu::make('menu', function ($menu) {`
`    $menu->add('Testing');`
`    $menu->add('Example One');`
`    $menu->exampleOne->add('Example Two');`
`    $menu->exampleOne->add('Example Three');`
`    dd($menu);`
`});`

exampleOne
exampleTwo
exampleThree