### PR TITLE
Ability to add menu to existing menu

### DIFF
--- a/src/Lavary/Menu/Menu.php
+++ b/src/Lavary/Menu/Menu.php
@@ -8,6 +8,13 @@ class Menu {
 	* @var Illuminate\Support\Collection
 	*/
 	protected $collection;
+	
+	/**
+	 * List of menu items
+	 * 
+	 * @var Lavary\Menu\Menu
+	 */
+	protected $menu = [];
 
 	/**
 	 * Initializing the menu builder
@@ -30,19 +37,20 @@ class Menu {
 	{
 		if(is_callable($callback))
 		{
-			
-			$menu = new Builder($name, $this->loadConf($name));
+			if (!array_key_exists($name, $this->menu)) {
+				$this->menu[$name] = new Builder($name, $this->loadConf($name));	
+			}
 			
 			// Registering the items
-			call_user_func($callback, $menu);
+			call_user_func($callback, $this->menu[$name]);
 			
 			// Storing each menu instance in the collection
-			$this->collection->put($name, $menu);
+			$this->collection->put($name, $this->menu[$name]);
 			
 			// Make the instance available in all views
-			\View::share($name, $menu);
+			\View::share($name, $this->menu[$name]);
 
-			return $menu;
+			return $this->menu[$name];
 		}
 	}
 


### PR DESCRIPTION
This commit provides ability to add menu items to already existing menu.

For example, 

        $menu = app('menu');
        $menu->make('AdminNavBar', function($menu){
            $menu->add('Service', ['route' => 'admin.services.index', 'class' => 'treeview'])
                ->prepend('<i class="fa fa-list-ul"></i><span>')
                ->append('</span>');
        });

creates navbar in the name of AdminNavbar. If I would like to add menu items to AdminNavbar, I can simply do

        $menu = app('menu');
        $menu->make('AdminNavBar', function($menu){
            $menu->add('Category', ['route' => 'admin.categories.index', 'class' => 'treeview'])
                ->prepend('<i class="fa fa-list-ul"></i><span>')
                ->append('</span>');
        });