### PR TITLE
Custom Active Attribute on Link not working

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,19 @@
 {
-    "name": "lavary/laravel-menu",
+    "name": "nmkr/laravel-menu",
     "description": "A quick way to create menus in Laravel 5",
     "keywords": [
         "laravel"
     ],
-    "homepage": "https://github.com/lavary/laravel-menu",
+    "homepage": "https://github.com/nmkr/laravel-menu",
     "authors": [
         {
             "name": "Lavary",
             "email": "mrl.8081@gmail.com"
-         }
+        },
+        {
+            "name": "NMKR",
+            "email": "office@nmkr.at"
+        }
     ],
     "license": "MIT",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,18 +1,14 @@
 {
-    "name": "nmkr/laravel-menu",
+    "name": "lavary/laravel-menu",
     "description": "A quick way to create menus in Laravel 5",
     "keywords": [
         "laravel"
     ],
-    "homepage": "https://github.com/nmkr/laravel-menu",
+    "homepage": "https://github.com/lavary/laravel-menu",
     "authors": [
         {
             "name": "Lavary",
             "email": "mrl.8081@gmail.com"
-        },
-        {
-            "name": "NMKR",
-            "email": "office@nmkr.at"
         }
     ],
     "license": "MIT",

--- a/src/Lavary/Menu/Item.php
+++ b/src/Lavary/Menu/Item.php
@@ -107,7 +107,7 @@ class Item {
 		}
 
 		
-		$this->link = $path ? new Link($path) : null;
+		$this->link = $path ? new Link($path, $this->builder) : null;
 		
 		// Activate the item if items's url matches the request uri
 		if( true === $this->builder->conf('auto_activate') ) {

--- a/src/Lavary/Menu/Link.php
+++ b/src/Lavary/Menu/Link.php
@@ -48,7 +48,7 @@ class Link {
 	 */
 	public function active(){
 	
-		$this->attributes['class'] = Builder::formatGroupClass(array('class' => 'active'), $this->attributes);
+		$this->attributes['class'] = Builder::formatGroupClass(array('class' => $this->builder->conf('active_class')), $this->attributes);
 		$this->isActive = true;
 		return $this;
 	}

--- a/src/Lavary/Menu/Link.php
+++ b/src/Lavary/Menu/Link.php
@@ -3,6 +3,13 @@
 class Link {
 	
 	/**
+	 * Reference to the menu builder
+	 *
+	 * @var Lavary\Menu\Menu
+	 */
+	protected $builder;
+	
+	/**
 	 * Path Information
 	 *
 	 * @var array
@@ -36,9 +43,10 @@ class Link {
 	 * @param  array  $path
 	 * @return void
 	 */
-	public function __construct($path = array())
+	public function __construct($path = array(), $builder)
 	{
 		$this->path = $path;
+		$this->builder = $builder;
 	}
 
 	/**


### PR DESCRIPTION
the method in Lavary\Menu\Link does not respect the config setting for an active link.. 

Link::class

    $this->attributes['class'] = Builder::formatGroupClass(array('class' => 'active'), $this->attributes);

should be

    $this->attributes['class'] = Builder::formatGroupClass(array('class' => $this->builder->conf('active_class')), $this->attributes);