### PR TITLE
Add nohref option for anchors

### DIFF
--- a/src/Lavary/Menu/Builder.php
+++ b/src/Lavary/Menu/Builder.php
@@ -35,7 +35,7 @@ class Builder {
 	*
 	* @var array
 	*/
-	protected $reserved = array('route', 'action', 'url', 'prefix', 'parent', 'secure', 'raw');
+	protected $reserved = array('route', 'action', 'url', 'prefix', 'parent', 'secure', 'raw', 'nohref');
 	
 	/**
 	 * Initializing the menu manager
@@ -518,7 +518,7 @@ class Builder {
 			$items  .= '<' . $item_tag . self::attributes($item->attr()) . '>';
 
 			if($item->link) {
-				$items .= '<a' . self::attributes($item->link->attr()) . ' href="' . $item->url() . '">' . $item->title . '</a>';
+				$items .= '<a' . self::attributes($item->link->attr()) . ($item->link->nohref ? '' : ' href="' . $item->url() . '"') . '>' . $item->title . '</a>';
 			} else {
 				$items .= $item->title;
 			}

--- a/src/Lavary/Menu/Item.php
+++ b/src/Lavary/Menu/Item.php
@@ -98,7 +98,7 @@ class Item {
 
 		} else {	
 			
-			$path = array_only($options, array('url', 'route', 'action', 'secure'));
+			$path = array_only($options, array('url', 'route', 'action', 'secure', 'nohref'));
 		} 
 
 		if(!is_null($path)) {

--- a/src/Lavary/Menu/Link.php
+++ b/src/Lavary/Menu/Link.php
@@ -31,6 +31,13 @@ class Link {
 	public $isActive = false;
 	
 	/**
+	 * Flag for hide/show href
+	 *
+	 * @var bool
+	 */
+	public $nohref = false;
+	
+	/**
 	 * Creates a hyper link instance
 	 *
 	 * @param  array  $path
@@ -39,6 +46,9 @@ class Link {
 	public function __construct($path = array())
 	{
 		$this->path = $path;
+		if (isset($path['nohref'])) {
+			$this->nohref = $path['nohref'];
+		}
 	}
 
 	/**


### PR DESCRIPTION
Add nohref option for anchors. Usage example:

`$menu->add('Menu item', array('url' => 'test', 'nohref' => true));`

So output will be: 

`<li><a>Menu item</a></li>`

instead of

`<li><a href="test">Menu item</a></li>`

This PR references to #141
