### PR TITLE
Fixed boot is not working with Laravel 5.5

### DIFF
--- a/src/Lavary/Menu/ServiceProvider.php
+++ b/src/Lavary/Menu/ServiceProvider.php
@@ -21,7 +21,7 @@ class ServiceProvider extends BaseServiceProvider {
 		 $this->mergeConfigFrom(__DIR__ . '/../../config/settings.php', 'laravel-menu.settings');
 		 $this->mergeConfigFrom(__DIR__ . '/../../config/views.php'   , 'laravel-menu.views');
 		 
-		 $this->app->singleton('menu', function($app) {
+		 $this->app->singleton(Menu::class, function($app) {
 		 	return new Menu;
 		 });            
 	}

--- a/src/Lavary/Menu/ServiceProvider.php
+++ b/src/Lavary/Menu/ServiceProvider.php
@@ -52,7 +52,7 @@ class ServiceProvider extends BaseServiceProvider {
 	 */
 	public function provides()
 	{
-		return array('menu');
+		return array(Menu::class);
 	}
 
 }


### PR DESCRIPTION
I had a problem with the defered service provider not booting with Laravel 5.5.
This change will fix the issue.