### PR TITLE
Fixed sortBy closure call throwing exception (#225)

### DIFF
--- a/src/Lavary/Menu/Builder.php
+++ b/src/Lavary/Menu/Builder.php
@@ -473,6 +473,7 @@ class Builder
             }
 
             $this->items = new Collection($rslt);
+            return $this;
         }
 
         // running the sort proccess on the sortable items


### PR DESCRIPTION
skipping the built in sorting when custom sorting by passing a closure to sortBy