### PR TITLE
Replaced deprecated helper functions [Laravel 5.8]

### DIFF
--- a/src/Lavary/Menu/Builder.php
+++ b/src/Lavary/Menu/Builder.php
@@ -2,6 +2,7 @@
 
 namespace Lavary\Menu;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\URL;
 
 class Builder
@@ -242,7 +243,7 @@ class Builder
 
         $new['class'] = self::formatGroupClass($new, $old);
 
-        return array_merge(array_except($old, array('prefix', 'class')), $new);
+        return array_merge(Arr::except($old, array('prefix', 'class')), $new);
     }
 
     /**
@@ -324,7 +325,7 @@ class Builder
             $options = $this->mergeWithLastGroup($options);
         }
 
-        return array_except($options, $this->reserved);
+        return Arr::except($options, $this->reserved);
     }
 
     /**
@@ -770,7 +771,7 @@ class Builder
         $attrs['class'] = self::formatGroupClass($attrs, $old);
 
         // Merging new and old array and parse it as a string
-        return self::attributes(array_merge(array_except($old, array('class')), $attrs));
+        return self::attributes(array_merge(Arr::except($old, array('class')), $attrs));
     }
 
     /**

--- a/src/Lavary/Menu/Item.php
+++ b/src/Lavary/Menu/Item.php
@@ -2,6 +2,7 @@
 
 namespace Lavary\Menu;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Request;
 
@@ -64,6 +65,13 @@ class Item
     protected $parent;
 
     /**
+     * Holds link element.
+     *
+     * @var Link|null
+     */
+    protected $link;
+
+    /**
      * Extra information attached to the menu item.
      *
      * @var array
@@ -94,18 +102,17 @@ class Item
     /**
      * Creates a new Item instance.
      *
-     * @param string  $title
-     * @param string  $url
-     * @param array   $attributes
-     * @param int     $parent
      * @param Builder $builder
+     * @param int     $id
+     * @param string  $title
+     * @param array   $options
      */
     public function __construct($builder, $id, $title, $options)
     {
         $this->builder = $builder;
         $this->id = $id;
         $this->title = $title;
-        $this->nickname = isset($options['nickname']) ? $options['nickname'] : camel_case(Str::ascii($title));
+        $this->nickname = isset($options['nickname']) ? $options['nickname'] : Str::camel(Str::ascii($title));
 
         $this->attributes = $this->builder->extractAttributes($options);
         $this->parent = (is_array($options) && isset($options['parent'])) ? $options['parent'] : null;
@@ -116,7 +123,7 @@ class Item
         } elseif (isset($options['raw']) && true == $options['raw']) {
             $path = null;
         } else {
-            $path = array_only($options, array('url', 'route', 'action', 'secure'));
+            $path = Arr::only($options, array('url', 'route', 'action', 'secure'));
         }
 
         if (!is_null($path)) {
@@ -134,8 +141,9 @@ class Item
     /**
      * Creates a sub Item.
      *
-     * @param string       $title
+     * @param string $title
      * @param string|array $options
+     * @return Item
      */
     public function add($title, $options = '')
     {
@@ -153,6 +161,8 @@ class Item
     /**
      * Add a plain text item.
      *
+     * @param $title
+     * @param array $options
      * @return Item
      */
     public function raw($title, array $options = array())
@@ -163,7 +173,7 @@ class Item
     }
 
     /**
-     * Insert a seprator after the item.
+     * Insert a separator after the item.
      *
      * @param array $attributes
      *
@@ -224,7 +234,7 @@ class Item
     {
         // If the item has a link proceed:
         if (!is_null($this->link)) {
-            // If item's link has `href` property explcitly defined
+            // If item's link has `href` property explicitly defined
             // return it
             if ($this->link->href) {
                 return $this->link->href;
@@ -238,6 +248,7 @@ class Item
     /**
      * Prepends text or html to the item.
      *
+     * @param $html
      * @return Item
      */
     public function prepend($html)
@@ -250,6 +261,7 @@ class Item
     /**
      * Appends text or html to the item.
      *
+     * @param $html
      * @return Item
      */
     public function append($html)
@@ -262,6 +274,7 @@ class Item
     /**
      * Before text or html to the item.
      *
+     * @param $html
      * @return Item
      */
     public function before($html)
@@ -274,6 +287,7 @@ class Item
     /**
      * After text or html to the item.
      *
+     * @param $html
      * @return Item
      */
     public function after($html)
@@ -399,6 +413,7 @@ class Item
      * Activate the item.
      *
      * @param Item $item
+     * @param bool $recursion
      */
     public function activate(Item $item = null, $recursion = false)
     {
@@ -427,6 +442,7 @@ class Item
     /**
      * Make the item active.
      *
+     * @param null|string $pattern
      * @return Item
      */
     public function active($pattern = null)


### PR DESCRIPTION
As in Laravel 5.8 the helper functions `array_except`, `array_only` and `camel_case` are marked as deprecated. 
This PR fixes the warnings and makes it compatible with future releases while keeping backwards compatibility. Also some PHPDoc updates and typo fixes.