### PR TITLE
rename array_get() to Arr::get(), array_get() doesn't work in laravel 6

### DIFF
--- a/src/Lavary/Menu/Builder.php
+++ b/src/Lavary/Menu/Builder.php
@@ -257,10 +257,10 @@ class Builder
     public static function formatGroupPrefix($new, $old)
     {
         if (isset($new['prefix'])) {
-            return trim(array_get($old, 'prefix'), '/').'/'.trim($new['prefix'], '/');
+            return trim(Arr::get($old, 'prefix'), '/').'/'.trim($new['prefix'], '/');
         }
 
-        return array_get($old, 'prefix');
+        return Arr::get($old, 'prefix');
     }
 
     /**
@@ -271,7 +271,7 @@ class Builder
     public function getLastGroupPrefix()
     {
         if (count($this->groupStack) > 0) {
-            return array_get(last($this->groupStack), 'prefix', '');
+            return Arr::get(last($this->groupStack), 'prefix', '');
         }
 
         return null;
@@ -300,12 +300,12 @@ class Builder
     public static function formatGroupClass($new, $old)
     {
         if (isset($new['class'])) {
-            $classes = trim(trim(array_get($old, 'class')).' '.trim(array_get($new, 'class')));
+            $classes = trim(trim(Arr::get($old, 'class')).' '.trim(Arr::get($new, 'class')));
 
             return implode(' ', array_unique(explode(' ', $classes)));
         }
 
-        return array_get($old, 'class');
+        return Arr::get($old, 'class');
     }
 
     /**


### PR DESCRIPTION
Please approve this one