### PR TITLE
Items property should be of type Collection

### DIFF
--- a/src/Lavary/Menu/Builder.php
+++ b/src/Lavary/Menu/Builder.php
@@ -10,7 +10,7 @@ class Builder
     /**
      * The items container.
      *
-     * @var array
+     * @var Collection
      */
     protected $items;
 


### PR DESCRIPTION
The $items property of the Builder is of type array, but should be Collection (see constructor: `$this->items = new Collection();`).