### PR TITLE
Changes linked to Issue #246

### DIFF
--- a/src/Lavary/Menu/Builder.php
+++ b/src/Lavary/Menu/Builder.php
@@ -628,7 +628,11 @@ class Builder
                     ]);
                 }
             }
-            $items .= '<'.$item_tag.self::attributes($item->attr() + $item_attributes).'>';
+            $all_attributes = array_merge($item_attributes, $item->attr()) ;
+            if (isset($item_attributes['class'])) {
+                $all_attributes['class'] = $all_attributes['class'].' '.$item_attributes['class'] ;
+            }
+            $items .= '<'.$item_tag.self::attributes($all_attributes).'>';
 
             if ($item->link) {
                 $items .= $item->beforeHTML.'<a'.self::attributes($link_attr).(!empty($item->url()) ? ' href="'.$item->url().'"' : '').'>'.$item->title.'</a>'.$item->afterHTML;


### PR DESCRIPTION
This correct this case :
- Generate menu and add item with Item::add() with option class value
- Render menu with option $item_attributes with an other class value
The result class of item won't have a merge of class attributes. This correct "only" for class attributes with merging both attributes (and active). Maybe other attributes values should be merged ?