### PR TITLE
Fix PHPDoc annotations to indicate nullable

### DIFF
--- a/src/Lavary/Menu/Builder.php
+++ b/src/Lavary/Menu/Builder.php
@@ -104,7 +104,7 @@ class Builder
     /**
      * Returns menu item by name.
      *
-     * @return Item
+     * @return Item|null
      */
     public function get($title)
     {
@@ -114,7 +114,7 @@ class Builder
     /**
      * Returns menu item by Id.
      *
-     * @return Item
+     * @return Item|null
      */
     public function find($id)
     {
@@ -134,7 +134,7 @@ class Builder
     /**
      * Return the first item in the collection.
      *
-     * @return Item
+     * @return Item|null
      */
     public function first()
     {
@@ -144,7 +144,7 @@ class Builder
     /**
      * Return the last item in the collection.
      *
-     * @return Item
+     * @return Item|null
      */
     public function last()
     {
@@ -156,7 +156,7 @@ class Builder
      *
      * @param string $title
      *
-     * @return Item
+     * @return Item|null
      */
     public function item($title)
     {
@@ -166,7 +166,7 @@ class Builder
     /**
      * Returns the first item marked as active.
      *
-     * @return Item
+     * @return Item|null
      */
     public function active()
     {

--- a/src/Lavary/Menu/Item.php
+++ b/src/Lavary/Menu/Item.php
@@ -341,7 +341,7 @@ class Item
     /**
      * Returns the parent item.
      *
-     * @return Item
+     * @return Item|null
      */
     public function parent()
     {


### PR DESCRIPTION
Some PHPDoc are incorrect, indicating the method will never return `null`.

This can cause some issue for static analysers like PHPStan.