### PR TITLE
fix params order in Link::__construct for php8 support

### DIFF
--- a/src/Lavary/Menu/Builder.php
+++ b/src/Lavary/Menu/Builder.php
@@ -299,7 +299,7 @@ class Builder
      */
     public static function formatGroupClass($new, $old)
     {
-        if (isset($new['class'])) {
+        if (isset($new['class']) and $new['class'] !== null) {
             $classes = trim(trim(Arr::get($old, 'class')).' '.trim(Arr::get($new, 'class')));
 
             return implode(' ', array_unique(explode(' ', $classes)));

--- a/src/Lavary/Menu/Item.php
+++ b/src/Lavary/Menu/Item.php
@@ -141,7 +141,7 @@ class Item
             $path['prefix'] = $this->builder->getLastGroupPrefix();
         }
 
-        $this->link = $path ? new Link($this->builder, $path) : null;
+        $this->link = $path ? new Link($path, $this->builder) : null;
 
         // Activate the item if items's url matches the request uri
         if (true === $this->builder->conf('auto_activate')) {

--- a/src/Lavary/Menu/Item.php
+++ b/src/Lavary/Menu/Item.php
@@ -141,7 +141,7 @@ class Item
             $path['prefix'] = $this->builder->getLastGroupPrefix();
         }
 
-        $this->link = $path ? new Link($path, $this->builder) : null;
+        $this->link = $path ? new Link($this->builder, $path) : null;
 
         // Activate the item if items's url matches the request uri
         if (true === $this->builder->conf('auto_activate')) {

--- a/src/Lavary/Menu/Link.php
+++ b/src/Lavary/Menu/Link.php
@@ -42,13 +42,13 @@ class Link
     /**
      * Creates a hyper link instance.
      *
-     * @param array   $path
      * @param Builder $builder
+     * @param array   $path
      */
-    public function __construct($path = array(), $builder)
+    public function __construct($builder, $path = array())
     {
-        $this->path = $path;
         $this->builder = $builder;
+        $this->path = $path;
     }
 
     /**

--- a/src/Lavary/Menu/Link.php
+++ b/src/Lavary/Menu/Link.php
@@ -7,7 +7,7 @@ class Link
     /**
      * Reference to the menu builder.
      *
-     * @var Builder
+     * @var Builder | null
      */
     protected $builder;
 
@@ -42,13 +42,13 @@ class Link
     /**
      * Creates a hyper link instance.
      *
-     * @param Builder $builder
      * @param array   $path
+     * @param Builder $builder
      */
-    public function __construct($builder, $path = array())
+    public function __construct($path = array(), $builder = null)
     {
-        $this->builder = $builder;
         $this->path = $path;
+        $this->builder = $builder;
     }
 
     /**
@@ -58,7 +58,7 @@ class Link
      */
     public function active()
     {
-        $this->attributes['class'] = Builder::formatGroupClass(array('class' => $this->builder->conf('active_class')), $this->attributes);
+        $this->attributes['class'] = Builder::formatGroupClass(array('class' => $this->builder ? $this->builder->conf('active_class') : null), $this->attributes);
         $this->isActive = true;
 
         return $this;


### PR DESCRIPTION
Hello! In php8 param with default value before required param throws an exception. Fix it.