### PR TITLE
Add ability to use bootstrap 5(beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://poser.pugx.org/lavary/laravel-menu/license.svg)](https://packagist.org/packages/lavary/laravel-menu)
 
 
-A quick and easy way to create menus in [Laravel 6](http://laravel.com/)
+A quick and easy way to create menus in [Laravel 6, 7 and 8](http://laravel.com/)
 
 __For Laravel 4.x, check [version 1.5.0](https://github.com/lavary/laravel-menu/tree/v1.5.0)__
 
@@ -1358,6 +1358,8 @@ This is how your Bootstrap code is going to look like:
   </div><!-- /.container-fluid -->
 </nav>
 ```
+
+In case you are using bootstrap 5 (currently in beta) you need to set the `data-toggle-attribute` option from `data-toggle` to `data-bs-toggle` in your `config/laravel-menu/settings.php`.
 
 #### Adding class attributes to child items
 

--- a/src/Lavary/Menu/ServiceProvider.php
+++ b/src/Lavary/Menu/ServiceProvider.php
@@ -80,6 +80,10 @@ class ServiceProvider extends BaseServiceProvider
         Blade::directive('lm_endattrs', function ($expression) {
             return '<?php echo \Lavary\Menu\Builder::mergeStatic(ob_get_clean(), $lm_attrs); ?>';
         });
+
+        Blade::directive('data_toggle_attribute', function ($expression) {
+            return config('laravel-menu.settings.default.data_toggle_attribute');
+        });
     }
 
     /**

--- a/src/Lavary/Menu/resources/views/bootstrap-navbar-items.blade.php
+++ b/src/Lavary/Menu/resources/views/bootstrap-navbar-items.blade.php
@@ -1,6 +1,6 @@
 @foreach($items as $item)
   <li @lm_attrs($item) @if($item->hasChildren()) class="nav-item dropdown" @endif @lm_endattrs>
-    @if($item->link) <a @lm_attrs($item->link) @if($item->hasChildren()) class="nav-link dropdown-toggle" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" @else class="nav-link" @endif @lm_endattrs href="{!! $item->url() !!}">
+    @if($item->link) <a @lm_attrs($item->link) @if($item->hasChildren()) class="nav-link dropdown-toggle" role="button" @data_toggle_attribute="dropdown" aria-haspopup="true" aria-expanded="false" @else class="nav-link" @endif @lm_endattrs href="{!! $item->url() !!}">
       {!! $item->title !!}
       @if($item->hasChildren()) <b class="caret"></b> @endif
     </a>

--- a/src/config/settings.php
+++ b/src/config/settings.php
@@ -9,5 +9,6 @@ return array(
         'cascade_data' => true,
         'rest_base' => '',      // string|array
         'active_element' => 'item',  // item|link
+        'data-toggle-attribute' => 'data-toggle',
     ),
 );


### PR DESCRIPTION
Introduced a setting 'laravel-menu.settings.default.data_toggle_attribute'
which needs to be set to 'data-bs-toggle' when using bootstrap 5
(currently in beta).